### PR TITLE
Fix argument of addCharacteristicToService for iOS

### DIFF
--- a/ios/RNBLEPeripheral.m
+++ b/ios/RNBLEPeripheral.m
@@ -19,10 +19,10 @@ RCT_EXTERN_METHOD(
     primary:    (BOOL)primary
 )
 RCT_EXTERN_METHOD(
-    addCharacteristicToService: (NSString *)uuid
+    addCharacteristicToService: (NSString *)serviceUUID
+    uuid:                       (NSString *)uuid
     permissions:                (NSInteger *)permissions
     properties:                 (NSInteger *)properties
-    data:                       (NSString *)data
 )
 RCT_EXTERN_METHOD(
     start:

--- a/ios/RNBLEPeripheral.swift
+++ b/ios/RNBLEPeripheral.swift
@@ -45,13 +45,12 @@ class BLEPeripheral: RCTEventEmitter, CBPeripheralManagerDelegate {
         }
     }
     
-    @objc(addCharacteristicToService:uuid:permissions:properties:data:)
-    func addCharacteristicToService(_ serviceUUID: String, uuid: String, permissions: UInt, properties: UInt, data: String) {
+    @objc(addCharacteristicToService:uuid:permissions:properties:)
+    func addCharacteristicToService(_ serviceUUID: String, uuid: String, permissions: UInt, properties: UInt) {
         let characteristicUUID = CBUUID(string: uuid)
         let propertyValue = CBCharacteristicProperties(rawValue: properties)
         let permissionValue = CBAttributePermissions(rawValue: permissions)
-        let byteData: Data = data.data(using: .utf8)!
-        let characteristic = CBMutableCharacteristic( type: characteristicUUID, properties: propertyValue, value: byteData, permissions: permissionValue)
+        let characteristic = CBMutableCharacteristic( type: characteristicUUID, properties: propertyValue, value: nil, permissions: permissionValue)
         servicesMap[serviceUUID]?.characteristics?.append(characteristic)
         print("added characteristic to service")
     }


### PR DESCRIPTION
Fixed addCharacteristicToService to match the behavior of Android.

the value input for `CBMutableCharacteristic` should be `nil` so the value won't be cached and it can receive other values. 
https://developer.apple.com/documentation/corebluetooth/cbmutablecharacteristic